### PR TITLE
Add scroll-to-top functionality in pagination

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 </head>
 <body>
   <main>
-    <h1>My Book Page</h1>
+    <h1><a href="https://openlibrary.org/works/OL45804W">My Book Page</a></h1>
   
     <div class="search-bar">
       <input type="text" id="search-input" placeholder="Search...">

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     </div>
   
     <div id="loading-screen">
-      <p id="loading-text">Loading...</p>
+      <div id="loading-spinner"></div>
     </div>
   </main>
   <script src="script.js"></script>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 </head>
 <body>
   <main>
-    <h1><a href="https://openlibrary.org/works/OL45804W">My Book Page</a></h1>
+    <h1><a href="/">My Book Page</a></h1>
   
     <div class="search-bar">
       <input type="text" id="search-input" placeholder="Search...">

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
   
     <div class="container">
       <div class="row" id="book-list"></div>
+      <div id="paginationInfo"></div>
     </div>
   
     <div class="button-container">

--- a/script.js
+++ b/script.js
@@ -106,10 +106,11 @@ function displayBooks(books) {
 }
 
 function createCardElement(book) {
-  const { title, author_name, cover_i } = book;
+  const { title, author_name, cover_i, key } = book;
 
   const col = createElement('div', 'col-md-4');
   const card = createElement('div', 'card mb-3');
+
   const row = createElement('div', 'row g-0');
   const colImage = createElement('div', 'col-md-4');
   const colContent = createElement('div', 'col-md-8');
@@ -118,7 +119,12 @@ function createCardElement(book) {
   const coverImage = createImageElement(cover_i, title);
   colImage.appendChild(coverImage);
 
-  const titleElement = createElement('h5', 'card-title', limitTitleLines(title));
+  const link = createElement('a');
+  link.href = `https://openlibrary.org${key}`;
+  link.target = '_blank'; // Open link in a new tab
+
+  const titleElement = createElement('h5', 'card-title');
+  titleElement.textContent = limitTitleLines(title);
   titleElement.style.overflow = 'hidden';
   titleElement.style.textOverflow = 'ellipsis';
   titleElement.style.display = '-webkit-box';
@@ -126,7 +132,9 @@ function createCardElement(book) {
   titleElement.style.webkitLineClamp = '3';
 
   const firstAuthorName = getFirstAuthorName(author_name);
-  const authorsElement = createElement('p', 'card-text', 'Author(s): ' + firstAuthorName);
+  const authorsElement = createElement('p', 'card-text');
+  authorsElement.textContent = 'Author(s): ' + firstAuthorName;
+ 
   cardBody.appendChild(titleElement);
   cardBody.appendChild(authorsElement);
 
@@ -134,10 +142,18 @@ function createCardElement(book) {
   row.appendChild(colImage);
   row.appendChild(colContent);
   card.appendChild(row);
-  col.appendChild(card);
+  link.appendChild(card);
+  col.appendChild(link);
 
   return col;
 }
+
+
+
+
+
+
+
 
 function getFirstAuthorName(authors) {
   if (!authors || authors.length === 0) {
@@ -157,8 +173,6 @@ function limitTitleLines(title) {
 
   return title;
 }
-
-
 
 function createElement(tagName, className, text) {
   const element = document.createElement(tagName);
@@ -184,7 +198,6 @@ function createImageElement(coverId, altText) {
   img.className = 'card-img';
   return img;
 }
-
 
 searchInput.addEventListener('keydown', event => {
   if (event.key === 'Enter') {

--- a/script.js
+++ b/script.js
@@ -124,8 +124,9 @@ function createCardElement(book) {
   titleElement.style.display = '-webkit-box';
   titleElement.style.webkitBoxOrient = 'vertical';
   titleElement.style.webkitLineClamp = '3';
-  
-  const authorsElement = createElement('p', 'card-text', 'Author(s): ' + getFullNames(author_name).join(', '));
+
+  const firstAuthorName = getFirstAuthorName(author_name);
+  const authorsElement = createElement('p', 'card-text', 'Author(s): ' + firstAuthorName);
   cardBody.appendChild(titleElement);
   cardBody.appendChild(authorsElement);
 
@@ -138,9 +139,17 @@ function createCardElement(book) {
   return col;
 }
 
+function getFirstAuthorName(authors) {
+  if (!authors || authors.length === 0) {
+    return 'Author\'s name not available';
+  }
+
+  return authors[0];
+}
+
 function limitTitleLines(title) {
   const maxTitleLines = 3;
-  const maxTitleLength = 50; // Maximum number of characters per line
+  const maxTitleLength = 50;
 
   if (title.length > maxTitleLength * maxTitleLines) {
     title = title.substring(0, maxTitleLength * maxTitleLines) + '...';
@@ -149,14 +158,6 @@ function limitTitleLines(title) {
   return title;
 }
 
-
-function getFullNames(authors) {
-  if (!authors) {
-    return ['Author\'s name not available'];
-  }
-
-  return authors.map(author => author.trim());
-}
 
 
 function createElement(tagName, className, text) {

--- a/script.js
+++ b/script.js
@@ -44,12 +44,14 @@ function previousPage() {
   if (pageOffset >= limitPerPage) {
     pageOffset -= limitPerPage;
     fetchBooks();
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   }
 }
 
 function nextPage() {
   pageOffset += limitPerPage;
   fetchBooks();
+  window.scrollTo({ top: 0, behavior: 'smooth' });
 }
 
 function displayBooks(books) {

--- a/script.js
+++ b/script.js
@@ -119,8 +119,10 @@ function displayBooks(books) {
   const currentPage = Math.floor(pageOffset / limitPerPage) + 1;
 
   const paginationInfo = document.createElement('p');
-  paginationInfo.innerText = `Page ${currentPage} of ${totalPages}`;
-  bookList.appendChild(paginationInfo);
+paginationInfo.innerText = `Page ${currentPage} of ${totalPages}`;
+paginationInfo.className = 'pagination-info'; 
+
+bookList.appendChild(paginationInfo);
 
   const previousButton = document.getElementById('previous-button');
   previousButton.disabled = pageOffset === 0; // Disable on first page

--- a/script.js
+++ b/script.js
@@ -51,7 +51,10 @@ function displayBooks(books) {
   bookList.innerHTML = '';
 
   if (books.length === 0) {
-    bookList.innerHTML = '<p>No books found.</p>';
+    const noBooksText = document.createElement('p');
+    noBooksText.className = 'no-books-found';
+    noBooksText.innerText = 'No books found 😢';
+    bookList.appendChild(noBooksText);
     const previousButton = document.getElementById('previous-button');
     previousButton.disabled = true;
     const nextButton = document.getElementById('next-button');
@@ -95,17 +98,14 @@ function displayBooks(books) {
     title.className = 'card-title';
     title.innerText = book.title;
 
-    const description = document.createElement('p');
-    description.className = 'card-text';
-    description.innerText = book.description || 'No description available.';
-
-    const lastUpdated = document.createElement('p');
-    lastUpdated.className = 'card-text';
-    lastUpdated.innerHTML = `<small class="text-muted">Last updated: ${book.lastUpdated}</small>`;
+    const authorNames = book.author_name || ['Author\'s name not available'];
+    const authors = document.createElement('p');
+    authors.classList.add('card-text');
+    authors.innerText = 'Author(s): ' + authorNames.join(', ');
+    
 
     cardBody.appendChild(title);
-    cardBody.appendChild(description);
-    cardBody.appendChild(lastUpdated);
+    cardBody.appendChild(authors);
 
     colContent.appendChild(cardBody);
     row.appendChild(colContent);

--- a/script.js
+++ b/script.js
@@ -11,6 +11,8 @@ const nextButton = document.getElementById('next-button');
 const paginationInfo = document.createElement('p');
 paginationInfo.className = 'pagination-info';
 
+hideButtons();
+
 function searchBooks() {
   searchTerm = searchInput.value.trim();
   if (searchTerm === '') {
@@ -58,9 +60,8 @@ function displayBooks(books) {
     noBooksText.className = 'no-books-found';
     noBooksText.innerText = 'No books found 😢';
     bookList.appendChild(noBooksText);
-    previousButton.disabled = true;
-    nextButton.disabled = true;
     paginationInfo.innerText = '';
+    hideButtons();
     return;
   }
 
@@ -100,10 +101,22 @@ function displayBooks(books) {
     nextButton.onclick = nextPage;
   } else {
     paginationInfo.innerText = '';
-    previousButton.disabled = true;
-    nextButton.disabled = true;
+    hideButtons();
   }
+
+  showButtons();
 }
+
+function hideButtons() {
+  previousButton.style.display = 'none';
+  nextButton.style.display = 'none';
+}
+
+function showButtons() {
+  previousButton.style.display = 'inline-block';
+  nextButton.style.display = 'inline-block';
+}
+
 
 function createCardElement(book) {
   const { title, author_name, cover_i, key } = book;
@@ -147,12 +160,6 @@ function createCardElement(book) {
 
   return col;
 }
-
-
-
-
-
-
 
 
 function getFirstAuthorName(authors) {

--- a/script.js
+++ b/script.js
@@ -3,20 +3,25 @@ let pageOffset = 0;
 const limitPerPage = 12;
 let totalResults = 0;
 
+const searchInput = document.getElementById('search-input');
+const loadingScreen = document.getElementById('loading-screen');
+const bookList = document.getElementById('book-list');
+const previousButton = document.getElementById('previous-button');
+const nextButton = document.getElementById('next-button');
+const paginationInfo = document.createElement('p');
+paginationInfo.className = 'pagination-info';
+
 function searchBooks() {
-  const searchInput = document.getElementById('search-input');
   searchTerm = searchInput.value.trim();
   if (searchTerm === '') {
     alert('Please enter a search term.');
     return;
   }
   pageOffset = 0;
-
   fetchBooks();
 }
 
 function fetchBooks() {
-  const loadingScreen = document.getElementById('loading-screen');
   loadingScreen.style.display = 'block';
   const apiUrl = `https://openlibrary.org/search.json?q=${searchTerm}&limit=${limitPerPage}&offset=${pageOffset}`;
   fetch(apiUrl)
@@ -45,9 +50,7 @@ function nextPage() {
   fetchBooks();
 }
 
-
 function displayBooks(books) {
-  const bookList = document.getElementById('book-list');
   bookList.innerHTML = '';
 
   if (books.length === 0) {
@@ -55,80 +58,136 @@ function displayBooks(books) {
     noBooksText.className = 'no-books-found';
     noBooksText.innerText = 'No books found 😢';
     bookList.appendChild(noBooksText);
-    const previousButton = document.getElementById('previous-button');
     previousButton.disabled = true;
-    const nextButton = document.getElementById('next-button');
     nextButton.disabled = true;
+    paginationInfo.innerText = '';
     return;
   }
 
-  books.forEach(book => {
-    const col = document.createElement('div');
-    col.className = 'col-md-4';
+  const cardRows = [];
+  let currentRow = document.createElement('div');
+  currentRow.className = 'row';
 
-    const card = document.createElement('div');
-    card.className = 'card mb-3';
-    card.style.maxWidth = '540px';
+  books.forEach((book, index) => {
+    const card = createCardElement(book);
+    currentRow.appendChild(card);
 
-    const row = document.createElement('div');
-    row.className = 'row g-0';
-
-    const colImage = document.createElement('div');
-    colImage.className = 'col-md-4';
-
-    const coverImage = document.createElement('img');
-    if (book.cover_i) {
-      coverImage.src = `https://covers.openlibrary.org/b/id/${book.cover_i}-M.jpg`;
-    } else {
-      coverImage.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAEYCAMAAADCuiwhAAAAY1BMVEX///8AAAB1cXFybm53c3NwbGyJhoby8vL4+Ph6dnbo5+f8/Pzh4OCCfn5+enqNioq8urqwrq6TkJDa2dm/vb3S0dGZlpaxr6+qp6fe3d2fnZ3s6+vLysprZmaGgoKcmZllYGACtpK3AAAJNElEQVR4nO2aC5ubKhOAPQx4wTveEU3//688AyZpsptsN9vzzbftM+/ztDUq+AoDytjonz+Q6J/oj4OlqWBpKliaCpamgqWpYGkqWJoKlqaCpalgaSpYmgqWpoKlqWBpKliaCpamgqWpYGkq/j7pdNU6yX+r/jRJ0t+q4BEfSCfDZK2dnf6d+rupHX7vth/wXHptK6UUgLS/c9Um29r/vKmfSidWCWlORgqou6/X31dAKD2DKF2hiz4Wck6+XD+ptK4EHA3sYIuPrWRxbij81rIs4T7SZSm8UlrgkSP28dC6umG9k8bzligdwu4E/zk3gh6cc8s5+PAwDp8Vi/sdaeeup31aupEwHltJ03e+dD5YU1a7afBHU5s+GJp6Qg89+SNj769m67G3ZdzfSWtjTGHjMrZLYfdqt74VcneKy6oyc7hbPFyVo2vq2mEzLHNdVrF1r0lbqc7XzdPQvbnbYStjUPKURt0GBg3TRkGTR+ssldwBsgnPq0HiSeXlcod0IYQwahc4SowoMwCLt+pise2xEnDC81aDQ36vyhJUg+ePQmXxBuVj62fSsVD3w2+poZoK3RkJbZTXUC54pdEP0rzJwHZ6KIXE2DFCitielntpKWW86F5J2J3uS1F1UWrV1mjdg6ySKO0V1IPuLEho0hybbC60AxGv79WeS+9CLbe/80ZA62sYMNjTqFdZi9sScIzqESp/g32m5iBtdLJeBt9VWgwYabvIWt8zoIYoX7UPhEjJTEfJCKXv2c4I7LslhtJfa4asjx7wWenVQnY0vZHKRYkSJk2nEAZDDGOn9eoqsXvpbL4pd5UG/JHUEHv31ktHfhy7dhQyK6IVhPFDPJ8ApbGQ1Vgj9ox9RXr0aoG0G7BBihH2MHEc0Z5bKIc1BoN35rC39ziOMWQ3lL4PxLfSfs5PQkvjiDB7KZQM0psYQyQ0XrqpRIUVxiVA/Yo0zh7m2EpsVTsvHR/Scxiiy5bNiwI/9Lx0fbAH6eFT0vmc4cieMaZvpXs/tJtMlOcaX2rpJZPXeVrszocHHDK72PBAGsM+h86Ouho7M01TnE7yF6RxNioLLKS8dFJCeBjgIZR2JcxYIXZw/vAN4ukTcQSR4UBJsavApjgQASuKwkBUkR+YeDE4+QkcO8FPG1E72uEF6aaCGZX0IY3TxtFrOHvkHQ5Yf63TOC/vzT6QxllNHhxtsBgQ46CnSm5hRGs8nDXh1EaIsi/w7jb3SkuXImsK/NvPHlGH1Y09Royf8iIrsHf1hO328LXng1dTswHOufigOAoOJT4HAAfbMTmkJxD10Q7+3Qrw0OYD8J20CtLiMntcpTW2Cta+7ULivaYtXg02a4WXXmsI1wpj5iXpyOFEIY6Hc2hbi48yFV/mhmHbLqMkaSoFqgrtXm/Z7ezRyA2jqkA5f1687UF62/DG9IjOZnWb8i8M+WC2vfcPGZTGWRGl1f7iY/wxunj2DqOLL6wVkmt1+XreakCdW6koHj4NPd9kjZjOP5QZwjNM/frt/ZtI5zixwt62Nb4+PW3gK99EGpu6yoRS+Jj6xOLuu0hHqWtPxtj+1+38jaRfgaWpYGkqWJoKlqaCpan4C6XX9ZIqSq5bL4NFE/+av759F7rf5X99Mnv/oXQ+m9M5y9sb89XUej8aXDYV+Ar35sBqTZ3f/po/ufr5WLpW51VqMqtteH7ih7Riw/Vpt8H+5oCO4cdPab0rU3yuxo+lr0vrcybrS/R1jEveTon4zQEdi+1GOoZvJJ2m/qvc/096cW6JdDNP5/hO3DTPjT6+PeTHHudL5EU/z5MLS+xQ6Cp9LXJIh9qGO+l0aOfmYWbpa9JNKXv8I7MqZGy6OpP+x5RENhPhzF76Q8lU4ZEsC9mcqZQ/w2Ops+xcxEsrF2qzyU/pZaz8rtMHM8mL0pkoITNC+FR+tOLauTIlCLn49JfPzEUlVINfW4OMYyl8zj1qM3WVvi3ipWW2mVhJn4Y+S4cvFzWAGP8z6UqqKY9WkNkU5QP8wCbyef0+94ksn07cRO3zZD98msmVYDAOpp/SvsgpCbX1eZD2qft+E3iZQzpvQeGdrtgJz8fQq9Ji9+05gQzxkfqg9Xnw9Jy2no/kZ5SHdKoJOe0b6UuRPhTx4RGSmdZ/YzqksUzpA95V8DA1/SVpmLx0ow7pqOitVCHROZT+Gx6I6njI4WiKlRDvpW+K+IEYhqpTWPaQHnY4DUu3uEpU/xPp1GWb8gnhkDOsxZYOSobvB+uoNiWkfCed3xa5TnmDEhdpHJhCbZsv/ePr0u6pdO6UyOLZ2dDXPqnbY3S4w1lWY9O/C498OIrMl/DY0nfSYrcHp69Je7kjsha8/vJGOhmh8iF5xHS07mCPPs2H4wvK+TvNjfSlyM+YDm3SQtaepfFCNoTM4w8Xn5F22GLTmqZ6FjDqN9Kr/8CW5/rc0pGVQorWXw9jdE7zHFvtjfR9EZQWBs9LMlG5s/R6AnC477THT5LTv5TOcSJTso4lTqx9+ralLUjT90YcMR0N+NQQ4ZnW4XjEGKiE2N+0NBapr0X8lOdriHFSTi7ztP+egWUzEM/fKn+xCChMBR5ZTmF2k9shvQmM6aEUoNQ+liqkZ/MY1PHZL7EZqE2ONfhXw1Ze3/Lui+gd1FTiwBT+c+T5LS9tdhyJSpbNc6tfrVzWZjTIPIQR4+wpvGK4k+2P/5dg5k43J7tejh6lkmk0Y5N0uCM97y7G03xXRONjyY75gPWHb1jrfJr8DJ0Os7/g8+D41HJrXfXT/6TydLGR6mcLnXdF9Lvs7vp+1x1/4Rrxm8LSVLA0FSxNBUtTwdJUsDQVLE0FS1PB0lSwNBUsTQVLU8HSVLA0FSxNBUtTwdJUsDQVLE0FS1PB0lSwNBUsTQVLU8HSVLA0FSxNBUtTwdJUsDQVLE0FS1PB0lSwNBUsTQVLU8HSVLA0FSxNBUtTwdJUsDQVLE0FS1PB0lSwNBUsTQVLU8HSVLA0FSxNBUtTwdJUsDQVLE0FS1PB0lSwNBUsTQVLU8HSVLA0FSxNBUtTwdJUsDQVLE0FS1PB0lSwNBUsTQVLU8HSVLA0FSxNBUtTwdJUsDQVLE0FS1PB0lSwNBUsTQVLU8HSVLA0FSxNBUtTwdJUsDQVLE0FS1OB0n8g/wJ1g5UqoPQqfgAAAABJRU5ErkJggg=='; // Add a placeholder image path
+    if ((index + 1) % 3 === 0) {
+      cardRows.push(currentRow);
+      currentRow = document.createElement('div');
+      currentRow.className = 'row';
     }
-    coverImage.className = 'img-fluid rounded-start';
-    coverImage.alt = book.title;
-
-    colImage.appendChild(coverImage);
-    row.appendChild(colImage);
-
-    const colContent = document.createElement('div');
-    colContent.className = 'col-md-8';
-
-    const cardBody = document.createElement('div');
-    cardBody.className = 'card-body';
-
-    const title = document.createElement('h5');
-    title.className = 'card-title';
-    title.innerText = book.title;
-
-    const authorNames = book.author_name || ['Author\'s name not available'];
-    const authors = document.createElement('p');
-    authors.classList.add('card-text');
-    authors.innerText = 'Author(s): ' + authorNames.join(', ');
-    
-
-    cardBody.appendChild(title);
-    cardBody.appendChild(authors);
-
-    colContent.appendChild(cardBody);
-    row.appendChild(colContent);
-
-    card.appendChild(row);
-    col.appendChild(card);
-    bookList.appendChild(col);
   });
 
-  const totalPages = Math.ceil(totalResults / limitPerPage);
-  const currentPage = Math.floor(pageOffset / limitPerPage) + 1;
+  if (currentRow.childElementCount > 0) {
+    cardRows.push(currentRow);
+  }
 
-  const paginationInfo = document.createElement('p');
-paginationInfo.innerText = `Page ${currentPage} of ${totalPages}`;
-paginationInfo.className = 'pagination-info'; 
+  cardRows.forEach(row => {
+    bookList.appendChild(row);
+  });
 
-bookList.appendChild(paginationInfo);
+  if (totalResults > 0) {
+    const totalPages = Math.ceil(totalResults / limitPerPage);
+    const currentPage = Math.floor(pageOffset / limitPerPage) + 1;
+    paginationInfo.innerText = `Page ${currentPage} of ${totalPages}`;
+    bookList.appendChild(paginationInfo);
 
-  const previousButton = document.getElementById('previous-button');
-  previousButton.disabled = pageOffset === 0; // Disable on first page
-  previousButton.onclick = previousPage;
+    previousButton.disabled = pageOffset === 0;
+    previousButton.onclick = previousPage;
 
-  const nextButton = document.getElementById('next-button');
-  nextButton.disabled = pageOffset + limitPerPage >= totalResults; // Disable on last page
-  nextButton.onclick = nextPage;
+    nextButton.disabled = pageOffset + limitPerPage >= totalResults;
+    nextButton.onclick = nextPage;
+  } else {
+    paginationInfo.innerText = '';
+    previousButton.disabled = true;
+    nextButton.disabled = true;
+  }
 }
+
+function createCardElement(book) {
+  const { title, author_name, cover_i } = book;
+
+  const col = createElement('div', 'col-md-4');
+  const card = createElement('div', 'card mb-3');
+  const row = createElement('div', 'row g-0');
+  const colImage = createElement('div', 'col-md-4');
+  const colContent = createElement('div', 'col-md-8');
+  const cardBody = createElement('div', 'card-body');
+
+  const coverImage = createImageElement(cover_i, title);
+  colImage.appendChild(coverImage);
+
+  const titleElement = createElement('h5', 'card-title', limitTitleLines(title));
+  titleElement.style.overflow = 'hidden';
+  titleElement.style.textOverflow = 'ellipsis';
+  titleElement.style.display = '-webkit-box';
+  titleElement.style.webkitBoxOrient = 'vertical';
+  titleElement.style.webkitLineClamp = '3';
+  
+  const authorsElement = createElement('p', 'card-text', 'Author(s): ' + getFullNames(author_name).join(', '));
+  cardBody.appendChild(titleElement);
+  cardBody.appendChild(authorsElement);
+
+  colContent.appendChild(cardBody);
+  row.appendChild(colImage);
+  row.appendChild(colContent);
+  card.appendChild(row);
+  col.appendChild(card);
+
+  return col;
+}
+
+function limitTitleLines(title) {
+  const maxTitleLines = 3;
+  const maxTitleLength = 50; // Maximum number of characters per line
+
+  if (title.length > maxTitleLength * maxTitleLines) {
+    title = title.substring(0, maxTitleLength * maxTitleLines) + '...';
+  }
+
+  return title;
+}
+
+
+function getFullNames(authors) {
+  if (!authors) {
+    return ['Author\'s name not available'];
+  }
+
+  return authors.map(author => author.trim());
+}
+
+
+function createElement(tagName, className, text) {
+  const element = document.createElement(tagName);
+  if (className) {
+    element.className = className;
+  }
+  if (text) {
+    element.innerText = text;
+  }
+  return element;
+}
+
+function createImageElement(coverId, altText) {
+  const img = document.createElement('img');
+  if (coverId) {
+    img.src = `https://covers.openlibrary.org/b/id/${coverId}-M.jpg`;
+    img.alt = altText;
+  } else {
+    img.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAEYCAMAAADCuiwhAAAAY1BMVEX///8AAAB1cXFybm53c3NwbGyJhoby8vL4+Ph6dnbo5+f8/Pzh4OCCfn5+enqNioq8urqwrq6TkJDa2dm/vb3S0dGZlpaxr6+qp6fe3d2fnZ3s6+vLysprZmaGgoKcmZllYGACtpK3AAAJNElEQVR4nO2aC5ubKhOAPQx4wTveEU3//688AyZpsptsN9vzzbftM+/ztDUq+AoDytjonz+Q6J/oj4OlqWBpKliaCpamgqWpYGkqWJoKlqaCpalgaSpYmgqWpoKlqWBpKliaCpamgqWpYGkq/j7pdNU6yX+r/jRJ0t+q4BEfSCfDZK2dnf6d+rupHX7vth/wXHptK6UUgLS/c9Um29r/vKmfSidWCWlORgqou6/X31dAKD2DKF2hiz4Wck6+XD+ptK4EHA3sYIuPrWRxbij81rIs4T7SZSm8UlrgkSP28dC6umG9k8bzligdwu4E/zk3gh6cc8s5+PAwDp8Vi/sdaeeup31aupEwHltJ03e+dD5YU1a7afBHU5s+GJp6Qg89+SNj769m67G3ZdzfSWtjTGHjMrZLYfdqt74VcneKy6oyc7hbPFyVo2vq2mEzLHNdVrF1r0lbqc7XzdPQvbnbYStjUPKURt0GBg3TRkGTR+ssldwBsgnPq0HiSeXlcod0IYQwahc4SowoMwCLt+pise2xEnDC81aDQ36vyhJUg+ePQmXxBuVj62fSsVD3w2+poZoK3RkJbZTXUC54pdEP0rzJwHZ6KIXE2DFCitielntpKWW86F5J2J3uS1F1UWrV1mjdg6ySKO0V1IPuLEho0hybbC60AxGv79WeS+9CLbe/80ZA62sYMNjTqFdZi9sScIzqESp/g32m5iBtdLJeBt9VWgwYabvIWt8zoIYoX7UPhEjJTEfJCKXv2c4I7LslhtJfa4asjx7wWenVQnY0vZHKRYkSJk2nEAZDDGOn9eoqsXvpbL4pd5UG/JHUEHv31ktHfhy7dhQyK6IVhPFDPJ8ApbGQ1Vgj9ox9RXr0aoG0G7BBihH2MHEc0Z5bKIc1BoN35rC39ziOMWQ3lL4PxLfSfs5PQkvjiDB7KZQM0psYQyQ0XrqpRIUVxiVA/Yo0zh7m2EpsVTsvHR/Scxiiy5bNiwI/9Lx0fbAH6eFT0vmc4cieMaZvpXs/tJtMlOcaX2rpJZPXeVrszocHHDK72PBAGsM+h86Ouho7M01TnE7yF6RxNioLLKS8dFJCeBjgIZR2JcxYIXZw/vAN4ukTcQSR4UBJsavApjgQASuKwkBUkR+YeDE4+QkcO8FPG1E72uEF6aaCGZX0IY3TxtFrOHvkHQ5Yf63TOC/vzT6QxllNHhxtsBgQ46CnSm5hRGs8nDXh1EaIsi/w7jb3SkuXImsK/NvPHlGH1Y09Royf8iIrsHf1hO328LXng1dTswHOufigOAoOJT4HAAfbMTmkJxD10Q7+3Qrw0OYD8J20CtLiMntcpTW2Cta+7ULivaYtXg02a4WXXmsI1wpj5iXpyOFEIY6Hc2hbi48yFV/mhmHbLqMkaSoFqgrtXm/Z7ezRyA2jqkA5f1687UF62/DG9IjOZnWb8i8M+WC2vfcPGZTGWRGl1f7iY/wxunj2DqOLL6wVkmt1+XreakCdW6koHj4NPd9kjZjOP5QZwjNM/frt/ZtI5zixwt62Nb4+PW3gK99EGpu6yoRS+Jj6xOLuu0hHqWtPxtj+1+38jaRfgaWpYGkqWJoKlqaCpan4C6XX9ZIqSq5bL4NFE/+av759F7rf5X99Mnv/oXQ+m9M5y9sb89XUej8aXDYV+Ar35sBqTZ3f/po/ufr5WLpW51VqMqtteH7ih7Riw/Vpt8H+5oCO4cdPab0rU3yuxo+lr0vrcybrS/R1jEveTon4zQEdi+1GOoZvJJ2m/qvc/096cW6JdDNP5/hO3DTPjT6+PeTHHudL5EU/z5MLS+xQ6Cp9LXJIh9qGO+l0aOfmYWbpa9JNKXv8I7MqZGy6OpP+x5RENhPhzF76Q8lU4ZEsC9mcqZQ/w2Ops+xcxEsrF2qzyU/pZaz8rtMHM8mL0pkoITNC+FR+tOLauTIlCLn49JfPzEUlVINfW4OMYyl8zj1qM3WVvi3ipWW2mVhJn4Y+S4cvFzWAGP8z6UqqKY9WkNkU5QP8wCbyef0+94ksn07cRO3zZD98msmVYDAOpp/SvsgpCbX1eZD2qft+E3iZQzpvQeGdrtgJz8fQq9Ji9+05gQzxkfqg9Xnw9Jy2no/kZ5SHdKoJOe0b6UuRPhTx4RGSmdZ/YzqksUzpA95V8DA1/SVpmLx0ow7pqOitVCHROZT+Gx6I6njI4WiKlRDvpW+K+IEYhqpTWPaQHnY4DUu3uEpU/xPp1GWb8gnhkDOsxZYOSobvB+uoNiWkfCed3xa5TnmDEhdpHJhCbZsv/ePr0u6pdO6UyOLZ2dDXPqnbY3S4w1lWY9O/C498OIrMl/DY0nfSYrcHp69Je7kjsha8/vJGOhmh8iF5xHS07mCPPs2H4wvK+TvNjfSlyM+YDm3SQtaepfFCNoTM4w8Xn5F22GLTmqZ6FjDqN9Kr/8CW5/rc0pGVQorWXw9jdE7zHFvtjfR9EZQWBs9LMlG5s/R6AnC477THT5LTv5TOcSJTso4lTqx9+ralLUjT90YcMR0N+NQQ4ZnW4XjEGKiE2N+0NBapr0X8lOdriHFSTi7ztP+egWUzEM/fKn+xCChMBR5ZTmF2k9shvQmM6aEUoNQ+liqkZ/MY1PHZL7EZqE2ONfhXw1Ze3/Lui+gd1FTiwBT+c+T5LS9tdhyJSpbNc6tfrVzWZjTIPIQR4+wpvGK4k+2P/5dg5k43J7tejh6lkmk0Y5N0uCM97y7G03xXRONjyY75gPWHb1jrfJr8DJ0Os7/g8+D41HJrXfXT/6TydLGR6mcLnXdF9Lvs7vp+1x1/4Rrxm8LSVLA0FSxNBUtTwdJUsDQVLE0FS1PB0lSwNBUsTQVLU8HSVLA0FSxNBUtTwdJUsDQVLE0FS1PB0lSwNBUsTQVLU8HSVLA0FSxNBUtTwdJUsDQVLE0FS1PB0lSwNBUsTQVLU8HSVLA0FSxNBUtTwdJUsDQVLE0FS1PB0lSwNBUsTQVLU8HSVLA0FSxNBUtTwdJUsDQVLE0FS1PB0lSwNBUsTQVLU8HSVLA0FSxNBUtTwdJUsDQVLE0FS1PB0lSwNBUsTQVLU8HSVLA0FSxNBUtTwdJUsDQVLE0FS1PB0lSwNBUsTQVLU8HSVLA0FSxNBUtTwdJUsDQVLE0FS1OB0n8g/wJ1g5UqoPQqfgAAAABJRU5ErkJggg=='; 
+    img.alt = 'Cover not available';
+    img.className = 'card-img-top';
+  }
+  img.className = 'card-img';
+  return img;
+}
+
+
+searchInput.addEventListener('keydown', event => {
+  if (event.key === 'Enter') {
+    event.preventDefault();
+    searchBooks();
+  }
+});

--- a/style.css
+++ b/style.css
@@ -1,7 +1,3 @@
-body * {
-border: dashed 1px red
-}
-
 #loading-screen {
     display: none;
     position: fixed;

--- a/style.css
+++ b/style.css
@@ -9,14 +9,25 @@
     z-index: 9999;
   }
   
-  #loading-text {
+  #loading-spinner {
     position: absolute;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    font-size: 24px;
-    color: #333;
+    display: inline-block;
+    width: 40px;
+    height: 40px;
+    border: 4px solid #f3f3f3;
+    border-top: 4px solid #333;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
   }
+
+  @keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+  }
+
   .card {
     height: 100%;
   }
@@ -50,3 +61,73 @@
     background-color: #f5f5f5; /* Set background color for the placeholder */
     padding: 1rem; /* Add padding to the placeholder */
   }
+
+  h1 {
+    text-align: center;
+    font-family: Arial, sans-serif;
+    font-size: 32px;
+    color: #333;
+    text-transform: uppercase;
+    padding: 20px;
+    background-color: #f2f2f2;
+    border-radius: 10px;
+  }
+
+  .search-bar {
+    text-align: center;
+    margin: 20px 0;
+  }
+  
+  .search-bar input[type="text"] {
+    padding: 10px;
+    width: 200px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 16px;
+  }
+  
+  .search-bar button {
+    padding: 10px 20px;
+    background-color: #333;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    font-size: 16px;
+    cursor: pointer;
+  }
+  
+  .search-bar button:hover {
+    background-color: #555;
+  }
+
+  .button-container {
+    text-align: center;
+    margin: 20px 0;
+  }
+  
+  .button-container button {
+    padding: 10px 20px;
+    background-color: #333;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    font-size: 16px;
+    cursor: pointer;
+    margin: 0 5px;
+  }
+  
+  .button-container button[disabled] {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  
+  .button-container button:hover {
+    background-color: #555;
+  }
+    .pagination-info {
+      text-align: center;
+      font-family: Arial, sans-serif;
+      font-size: 16px;
+      margin: 10px auto;
+    }
+    

--- a/style.css
+++ b/style.css
@@ -59,7 +59,8 @@
 
 .card-img-top {
   object-fit: cover;
-  height: 200px; /* Adjust the height as needed */
+  height: 200px;
+  /* Adjust the height as needed */
   width: 100%;
   max-width: 100%;
   margin-bottom: 0.5rem;
@@ -140,11 +141,39 @@ h1 {
   font-size: 16px;
   margin: 10px auto;
 }
+
 .no-books-found {
   text-align: center;
   font-family: Arial, sans-serif;
   font-size: 20px;
   color: #333;
   margin-top: 20px;
-  width: 100%; /* Add this line */
+  width: 100%;
+  /* Add this line */
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  color: inherit;
+  text-decoration: none;
+}
+
+
+h1 a {
+  color: inherit;
+  text-decoration: none;
+}
+
+h1 a:hover {
+  color: inherit;
+  text-decoration: none;
+}
+
+.card:hover {
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.4);
+  
 }

--- a/style.css
+++ b/style.css
@@ -1,133 +1,150 @@
 #loading-screen {
-    display: none;
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(255, 255, 255, 0.7);
-    z-index: 9999;
-  }
-  
-  #loading-spinner {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    display: inline-block;
-    width: 40px;
-    height: 40px;
-    border: 4px solid #f3f3f3;
-    border-top: 4px solid #333;
-    border-radius: 50%;
-    animation: spin 1s linear infinite;
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(255, 255, 255, 0.7);
+  z-index: 9999;
+}
+
+#loading-spinner {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: inline-block;
+  width: 40px;
+  height: 40px;
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #333;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
   }
 
-  @keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
+  100% {
+    transform: rotate(360deg);
   }
+}
 
-  .card {
-    height: 100%;
-  }
-  
-  .card-body {
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-  }
-  
-  .card-title {
-    margin-bottom: 0.5rem;
-  }
-  
-  .card-text {
-    flex-grow: 1;
-    margin-bottom: 0.5rem;
-  }
-  
-  .card-img-top {
-    object-fit: cover;
-    height: 200px; /* Adjust the height as needed */
-    width: 100%;
-  }
-  
-  .img-fluid {
-    object-fit: contain;
-    height: 200px; /* Adjust the height as needed */
-    width: 100%;
-    background-color: #f5f5f5; /* Set background color for the placeholder */
-    padding: 1rem; /* Add padding to the placeholder */
-  }
+.card {
+  align-items: center;
+  height: 100%;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 1rem;
+}
 
-  h1 {
-    text-align: center;
-    font-family: Arial, sans-serif;
-    font-size: 32px;
-    color: #333;
-    text-transform: uppercase;
-    padding: 20px;
-    background-color: #f2f2f2;
-    border-radius: 10px;
-  }
+.card-body {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
 
-  .search-bar {
-    text-align: center;
-    margin: 20px 0;
-  }
-  
-  .search-bar input[type="text"] {
-    padding: 10px;
-    width: 200px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    font-size: 16px;
-  }
-  
-  .search-bar button {
-    padding: 10px 20px;
-    background-color: #333;
-    color: #fff;
-    border: none;
-    border-radius: 4px;
-    font-size: 16px;
-    cursor: pointer;
-  }
-  
-  .search-bar button:hover {
-    background-color: #555;
-  }
+.card-title {
+  margin-bottom: 0.5rem;
+}
 
-  .button-container {
-    text-align: center;
-    margin: 20px 0;
-  }
-  
-  .button-container button {
-    padding: 10px 20px;
-    background-color: #333;
-    color: #fff;
-    border: none;
-    border-radius: 4px;
-    font-size: 16px;
-    cursor: pointer;
-    margin: 0 5px;
-  }
-  
-  .button-container button[disabled] {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-  
-  .button-container button:hover {
-    background-color: #555;
-  }
-    .pagination-info {
-      text-align: center;
-      font-family: Arial, sans-serif;
-      font-size: 16px;
-      margin: 10px auto;
-    }
-    
+.card-text {
+  flex-grow: 1;
+  margin-bottom: 0.5rem;
+}
+
+.card-img-top {
+  object-fit: cover;
+  height: 200px; /* Adjust the height as needed */
+  width: 100%;
+  max-width: 100%;
+  margin-bottom: 0.5rem;
+}
+
+.col-md-4 {
+  flex-basis: 33.33%;
+  margin-bottom: 20px;
+}
+
+
+h1 {
+  text-align: center;
+  font-family: Arial, sans-serif;
+  font-size: 32px;
+  color: #333;
+  text-transform: uppercase;
+  padding: 20px;
+  background-color: #f2f2f2;
+  border-radius: 10px;
+}
+
+.search-bar {
+  text-align: center;
+  margin: 20px 0;
+}
+
+.search-bar input[type="text"] {
+  padding: 10px;
+  width: 200px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 16px;
+}
+
+.search-bar button {
+  padding: 10px 20px;
+  background-color: #333;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+.search-bar button:hover {
+  background-color: #555;
+}
+
+.button-container {
+  text-align: center;
+  margin: 30px 0;
+}
+
+.button-container button {
+  padding: 10px 20px;
+  background-color: #333;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-size: 16px;
+  cursor: pointer;
+  margin: 0 5px;
+}
+
+.button-container button[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.button-container button:hover {
+  background-color: #555;
+}
+
+.pagination-info {
+  text-align: center;
+  font-family: Arial, sans-serif;
+  font-size: 16px;
+  margin: 10px auto;
+}
+.no-books-found {
+  text-align: center;
+  font-family: Arial, sans-serif;
+  font-size: 20px;
+  color: #333;
+  margin-top: 20px;
+  width: 100%; /* Add this line */
+}


### PR DESCRIPTION
This pull request adds a scroll-to-top functionality to the previousPage() and nextPage() functions in the pagination feature. The previous and next buttons now not only navigate between pages but also scroll the window to the top of the page after changing the page.

Changes Made:

Modified the previousPage() function to include a call to fetchBooks() and added a window.scrollTo() function to scroll to the top of the page.
Updated the nextPage() function to call fetchBooks() and added a window.scrollTo() function to scroll to the top of the page.
These changes ensure a better user experience by automatically scrolling the page to the top when the user navigates between pages, providing a seamless transition.
